### PR TITLE
Add Gemini tab with timer and settings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PySide6>=6.9.1
 requests>=2.31
+google-generativeai>=0.3.0

--- a/resources/instructions.txt
+++ b/resources/instructions.txt
@@ -1,0 +1,1 @@
+Summarize the following threat intelligence information and suggest appropriate mitigations.


### PR DESCRIPTION
## Summary
- implement GeminiTab widget that loads instructions, shows countdown timer, and queries Gemini API on timer completion
- add SettingsTab to capture API key and integrate with GeminiTab
- wire new tabs into MainWindow and document required library

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a224ecd7a8832abb73d17162f88090