### PR TITLE
Add feedparser dependency for feed fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6>=6.9.1
 requests>=2.31
 google-generativeai>=0.3.0
+feedparser>=6.0


### PR DESCRIPTION
## Summary
- add feedparser>=6.0 to requirements for feed handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc1bbfc4832a988969c16541b1e6