### PR TITLE
Process all feed items in feed scraper

### DIFF
--- a/main.py
+++ b/main.py
@@ -265,7 +265,9 @@ class FeedScraperTab(QtWidgets.QWidget):
                 items = root.findall('.//item')
                 if not items:
                     items = root.findall('.//{http://www.w3.org/2005/Atom}entry')
-                for item in items[:5]:
+                # TODO: Add a user-configurable limit or pagination to avoid
+                # excessive output for very long feeds.
+                for item in items:
                     title = item.findtext('title') or item.findtext('{http://www.w3.org/2005/Atom}title', '')
                     link = item.findtext('link')
                     if link is None:


### PR DESCRIPTION
## Summary
- Process every feed entry in `FeedScraperTab` instead of just the first five
- Note potential need for user-defined item limits or pagination for long feeds

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e4957ef0832a9f187a52393f0659