### PR TITLE
Set default Gemini API key in settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,9 @@ class SettingsTab(QtWidgets.QWidget):
 
     def load_settings(self):
         self.lm_endpoint_edit.setText(self.settings.value('lm_endpoint', DEFAULT_LM_URL))
-        self.api_key_edit.setText(self.settings.value('gemini_api_key', ''))
+        default_key = 'AIzaSyAwIloDIfDzd5OXTX2U_wPtOsW0cPuXPDs'
+        saved_key = self.settings.value('gemini_api_key')
+        self.api_key_edit.setText(saved_key if saved_key else default_key)
 
     def save_settings(self):
         self.settings.setValue('lm_endpoint', self.lm_endpoint_edit.text().strip())


### PR DESCRIPTION
## Summary
- Provide a default Gemini API key during settings load.
- Ensure the API key field populates with the default when no saved key exists.

## Testing
- `pytest`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PySide6 import QtWidgets, QtCore
from main import SettingsTab
app = QtWidgets.QApplication([])
QtCore.QSettings('ThreatAnalyst', 'NeonJoy').clear()
tab = SettingsTab()
print('API key:', tab.api_key_edit.text())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab64e6d800832a839f67f681a05e75