### PR TITLE
Strip script and style tags before scraping text

### DIFF
--- a/main.py
+++ b/main.py
@@ -323,6 +323,8 @@ class FeedScraperTab(QtWidgets.QWidget):
                     if BeautifulSoup:
                         try:
                             soup = BeautifulSoup(r.text, "html.parser")
+                            for tag in soup(["script", "style"]):
+                                tag.decompose()
                             text = soup.get_text(separator="\n", strip=True)
                         except Exception as e:
                             text = f"Error parsing {url}: {e}"


### PR DESCRIPTION
## Summary
- Clean up scraped HTML by removing script and style elements before text extraction.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab73094054832a9be1f6005dffca9d