### PR TITLE
Add BeautifulSoup dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PySide6>=6.9.1
 requests>=2.31
 google-generativeai>=0.3.0
 feedparser>=6.0
+beautifulsoup4>=4.13.5


### PR DESCRIPTION
## Summary
- ensure bs4 can be imported by adding beautifulsoup4>=4.13.5 to requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab7377121c832abae041e663add151