### PR TITLE
Include current time in Gemini prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -308,7 +308,9 @@ class FeedScraperTab(QtWidgets.QWidget):
                 age_str = f"{hours} hour{'s' if hours != 1 else ''}"
             else:
                 age_str = f"{max_age_minutes} minutes"
+            current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             prompt = (
+                f"The current time is {current_time}. "
                 f"Look at the time stamp and ignore anything older than {age_str} "
                 "then strip out the URLs that are left and just list the URLs and nothing else.\n\n"
                 + text


### PR DESCRIPTION
## Summary
- include the current system time in FeedScraperTab's Gemini prompt
- prepend timestamp to prompt so Gemini can filter items by age

## Testing
- `python -m py_compile main.py`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
import main
from PySide6 import QtWidgets
import google.generativeai as genai
import requests

class DummyResponse:
    def __init__(self):
        self.status_code = 200
        self.text = 'dummy'
    def raise_for_status(self):
        pass

def dummy_get(url, timeout=10):
    print('requests.get called', url)
    return DummyResponse()

class DummyModel:
    def __init__(self):
        self.prompt = None
    def generate_content(self, prompt):
        print('PROMPT:', prompt)
        class Resp:
            text = 'http://example.com/\n'
        return Resp()

def dummy_configure(api_key=None):
    print('configure called with', api_key)

class DummyContent:
    def update_webscraps(self, *args, **kwargs):
        print('update_webscraps called')

# patch
genai.GenerativeModel = lambda *args, **kwargs: DummyModel()
genai.configure = dummy_configure
requests.get = dummy_get

app = QtWidgets.QApplication([])
settings = main.SettingsTab()
feed = main.FeedScraperTab(settings, DummyContent())
feed.output.setPlainText('2024-06-01 01:00:00 some link http://example.com')
feed._send_to_gemini(15)
print('Gemini output:', feed.gemini_output.toPlainText())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ab7c3eb8fc832aaaa9e39b7da4187a