### PR TITLE
Use message helper for AI replies

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,8 +85,11 @@ class ChatTab(QtWidgets.QWidget):
         try:
             r = requests.post(url, json=payload, timeout=60); r.raise_for_status(); data = r.json()
             content = data['choices'][0]['message']['content']; tagged = json.loads(content) if isinstance(content, str) else content
-            reply = tagged.get('assistant_text','…'); emotion = tagged.get('emotion','neutral'); intensity = float(tagged.get('intensity', 0.5))
-            self.messages.append({'role':'assistant','content':reply}); self._append('AI', reply); self.avatar.set_emotion(emotion, intensity)
+            reply = tagged.get('assistant_text', '…')
+            emotion = tagged.get('emotion', 'neutral')
+            intensity = float(tagged.get('intensity', 0.5))
+            self.append_external_message('AI', reply)
+            self.avatar.set_emotion(emotion, intensity)
             
         except Exception as e:
             self._append('System', f"<span style='color:#ff7b7b'>Error: {e}</span>")


### PR DESCRIPTION
## Summary
- Expose `append_external_message` to add assistant messages to chat history
- Route LM Studio responses through the helper for consistent message bookkeeping
- Keep ContentTab forwarding Gemini analysis via the helper

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb000656c832a90fb32ee553ce72f