### PR TITLE
Remove explicit loop count for avatar movie

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,6 @@ class ChatTab(QtWidgets.QWidget):
         self.avatar = QtWidgets.QLabel()
         self.avatar_movie = QtGui.QMovie(str(assets / "Avatar1.gif"))
         self.avatar_movie.setCacheMode(QtGui.QMovie.CacheAll)
-        self.avatar_movie.setLoopCount(-1)  # loop forever
         self.avatar.setMovie(self.avatar_movie)
         self.avatar_movie.start()
         self.history = QtWidgets.QTextEdit(readOnly=True); self.input = QtWidgets.QLineEdit(placeholderText='Say something…'); self.sendBtn = QtWidgets.QPushButton('Send')


### PR DESCRIPTION
## Summary
- Avoid attribute error by removing unsupported `setLoopCount` call on avatar movie
- Rely on GIF's default looping behavior when showing the avatar

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68abce095ce0832a97a37a2775f40f39